### PR TITLE
added new css handle on filter navigator component inside of search-result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.56.2] - 2020-04-29
+### Added
+- new css handles: `filtersWrapper`
+
 ## [3.56.1] - 2020-04-24
 ### Fixed
 - Make query in component and done on SSR match.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "search-result",
   "vendor": "vtex",
-  "version": "3.56.1",
+  "version": "3.56.2",
   "title": "VTEX Search Result",
   "description": "A search result wrapper component",
   "mustUpdateAt": "2019-04-25",

--- a/react/FilterNavigator.js
+++ b/react/FilterNavigator.js
@@ -23,7 +23,7 @@ import styles from './searchResult.css'
 import { CATEGORIES_TITLE } from './utils/getFilters'
 import { newFacetPathName } from './utils/slug'
 
-const CSS_HANDLES = ['filter__container', 'filterMessage']
+const CSS_HANDLES = ['filter__container', 'filterMessage', 'filtersWrapper']
 
 const LAYOUT_TYPES = {
   responsive: 'responsive',
@@ -137,7 +137,7 @@ const FilterNavigator = ({
         </div>
       ) : (
         <Fragment>
-          <div className={filterClasses}>
+          <div className={handles.filtersWrapper}>
             <div
               className={`${applyModifiers(
                 handles.filter__container,

--- a/react/searchResult.css
+++ b/react/searchResult.css
@@ -56,6 +56,9 @@
   grid-row: filters;
 }
 
+.filtersWrapper {
+}
+
 .filter__container {
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
add a new css class on filter-navigator component

<!--- Describe your changes in detail. -->

#### What problem is this solving?
now it's possible to style this element with native css handle and without deprecated css selectors

<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?
Go to any VTEX IO store, make a search for products and Inspect Filter Navigator component with DevTools, you will could see the element below namespace `vtex-search-result-3-x-filters` without any css classes

#### Screenshots or example usage
Current element without css handle -> https://prnt.sc/s843za
Css Handle added -> https://prnt.sc/s84331

#### Types of changes

* [x] Bug fix (a non-breaking change which fixes an issue)
* [ ] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
